### PR TITLE
libTonNurako.extremesports ﾊﾟｽ修正

### DIFF
--- a/seedtable-x11/XmSeedtable/XmSeedtable.csproj
+++ b/seedtable-x11/XmSeedtable/XmSeedtable.csproj
@@ -89,7 +89,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>
-		  cp $(ProjectDir)../TonNurako/bin/$(ConfigurationName)/libTonNurako.extremesports $(TargetDir)
+		  cp $(SolutionDir)bin/$(ConfigurationName)/libTonNurako.extremesports $(TargetDir)
 	  </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.


### PR DESCRIPTION
ﾄﾝﾇﾗｺが$(SolutionDir)/bin への吐き出しに対し、XmSeedTableのcpが$(ProjectDir)になっていた箇所修正 (OpenSUSEで確認)